### PR TITLE
Cosmetic build adjustments

### DIFF
--- a/azure-pipelines/main.yml
+++ b/azure-pipelines/main.yml
@@ -36,6 +36,7 @@ stages:
         pool:
           #vmImage: $(image.name)
           name: $(pool.name)
+
         steps:
 
 # This can be used when running on a MS hosted agent:
@@ -110,6 +111,7 @@ stages:
               python -m twine upload -r $(basename ${ARTIFACTFEED}) --config-file ${PYPIRC_PATH} ${WHEELS_DIR}/*
             displayName: 'Upload to ray-feed'
           - task: ComponentGovernanceComponentDetection@0
+            condition: startsWith( variables['Build.SourceBranchName'], 'msft-')
             inputs:
               scanType: 'Register'
               verbosity: 'Verbose'

--- a/azure-pipelines/templates/python-env.yml
+++ b/azure-pipelines/templates/python-env.yml
@@ -26,8 +26,7 @@ steps:
       source $PENV_HOME/bin/activate
       echo switched to venv python: $(which python)
 
-      python -m pip install --upgrade pip six
+      python -m pip install --upgrade pip six wheel
       python -m pip install --upgrade setuptools mock 'future>=0.17.1'
       python -m pip install --upgrade twine
-      pip install -U pip numpy wheel
     displayName: 'Setup Python and Dependencies'


### PR DESCRIPTION
among other things, the governance task will run only on 'msft-' prefixed branches to eliminated governance data noise generated for the development branches should developers decide to run the build manually. 